### PR TITLE
Added YT shorts functionalities

### DIFF
--- a/assets/popup.html
+++ b/assets/popup.html
@@ -48,9 +48,6 @@
     <span class="pip-button" data-tooltip="Picture In Picture">
       <img src="images/pip_logo.png">
     </span>
-    <div class="autoscroll">
-      <button class="btn autoplay-button">Autoscroll Shorts</button>
-    </div>
     <div class="settings">
       <button class="btn settings-button">Settings</button>
   </div>


### PR DESCRIPTION
Fixes: #10 
Removed the shorts autoplay button as it wasn't required and the user can turn it on/off using shortcuts.
SHORTCUTS:-
Skip forward 5sec = Control+Shift+RightArrow
Skip backward 5sec = Control+Shift+LeftArrow
Turn on autoplay = Control+Shift+DownArrow
Turn off autoplay = Control+Shift+UpArrow
closes: #10 